### PR TITLE
Added round # as part of the UDP packet header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -178,9 +178,9 @@ cython_debug/
 /data
 /logs
 *.safetensors
-/results_worker_0
-/results_worker_1
-/results_worker_2
+results_worker_0
+results_worker_1
+results_worker_2
 *.pkl
 .DS_Store
 .server_port

--- a/distributed_trainer.py
+++ b/distributed_trainer.py
@@ -221,7 +221,11 @@ class DistributedTrainer(Trainer):
 
         # Call the parent's train method with our adjusted settings
         # This will still load the checkpoint state but won't skip training
-        result = super().train(resume_from_checkpoint=resume_checkpoint, trial=trial, ignore_keys_for_eval=ignore_keys_for_eval)
+        result = super().train(
+            resume_from_checkpoint=resume_checkpoint,
+            trial=trial,
+            ignore_keys_for_eval=ignore_keys_for_eval,
+        )
 
         print(f"Worker {self.worker_id} training completed successfully")
         self.print_total_network_latency()

--- a/distributed_trainer_multithreading.py
+++ b/distributed_trainer_multithreading.py
@@ -8,6 +8,7 @@ from torch.utils.data import DataLoader
 from transformers import Trainer
 
 import mlt
+import utility
 
 
 def custom_collate_fn(batch):
@@ -42,6 +43,8 @@ class DistributedTrainerMultithreading(Trainer):
         self.protocol = kwargs.pop("protocol", "MLT")
         self.loss_tolerance = kwargs.pop("loss_tolerance", 0.03)
         self.signal_counter = 0  # Initialize signal counter for MLT protocol
+        self.metadata_list = []  # Store metadata for MLT protocol
+        self.has_sent_metadata = False  # Track if metadata has been sent
 
         # network latency measurement
         self.start_time = 0
@@ -75,9 +78,6 @@ class DistributedTrainerMultithreading(Trainer):
         """Establishes connection with the server and gets the dedicated UDP port."""
         try:
             self.tcp_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            # self.tcp_sock.setsockopt(
-            #     socket.IPPROTO_TCP, socket.TCP_NODELAY, 1
-            # )  # Disable Nagle's algorithm for low latency
             self.tcp_sock.connect((self.server_host, self.tcp_port))
             worker_addr = self.tcp_sock.getsockname()
             print(f"[Worker {self.id}] Successfully connected to server at {self.server_host}:{self.tcp_port}")
@@ -188,6 +188,20 @@ class DistributedTrainerMultithreading(Trainer):
             gradients["eval_acc"] = self.eval_acc
             gradients["epoch"] = self.curr_epoch
 
+        # ZM 8/6/2025: metadata will only be sent once at the very beginning of the training
+        if not self.has_sent_metadata:
+            for key, tensor in gradients.items():
+                if not isinstance(tensor, torch.Tensor):
+                    raise ValueError(f"Gradient for key '{key}' is not a tensor: {type(tensor)}")
+                metadata, _ = mlt.serialize_gradient_to_custom_binary(self.tcp_sock, key, tensor)
+                self.metadata_list.append(metadata)
+
+            # send metadata to the server
+            utility.send_data_tcp(self.tcp_sock, self.metadata_list)
+            self.has_sent_metadata = True
+        else:
+            print(f"[Worker {self.id}] Metadata already sent: {len(self.metadata_list)} items. E.g. {self.metadata_list[0]}")
+
         # --------------- 6/27 UPDATES: bring in MLT -------------------------------
         self.start_time = time.perf_counter()  # Start measuring network latency
 
@@ -197,13 +211,9 @@ class DistributedTrainerMultithreading(Trainer):
 
         # 2. Wait to receive the globally averaged gradients from the server
 
-        # TODO: question: should we add a logic where we wait for a signal from the server
-        # that will inform the workers
-        # "Hey I am ready to send you back the averaged gradients"?
-
         print(f"[Worker {self.id}] Gradients sent. Waiting to receive averaged model back...")
         socks = {"tcp": self.tcp_sock, "udp": self.udp_sock}
-        result = mlt.recv_data_mlt(socks, (self.server_host, self.tcp_port), self.signal_counter)
+        result = mlt.recv_data_mlt(socks, (self.server_host, self.tcp_port), self.signal_counter, self.metadata_list)
         self.signal_counter += 1  # Increment signal counter after receiving
 
         self.end_time = time.perf_counter()
@@ -250,11 +260,7 @@ class DistributedTrainerMultithreading(Trainer):
             self.tcp_sock.sendall(b"N")
             print("WORKER: Sent 'no eval' signal 'N'.")
 
-        self.tcp_sock.sendall(struct.pack("!I", len(gradients_dict)))
-
         # instead of sending each gradient one by one, we will send them all at once
-        # including the metadata
-        metadata_list: list[dict] = []
         payload_bytes_list: list[bytes] = []
 
         socks = {"tcp": self.tcp_sock, "udp": self.udp_sock}
@@ -262,16 +268,15 @@ class DistributedTrainerMultithreading(Trainer):
         addrs["tcp"] = (self.server_host, self.tcp_port)
 
         for key, tensor in gradients_dict.items():
-            metadata, payload_bytes = mlt.serialize_gradient_to_custom_binary(self.tcp_sock, key, tensor)
-            if metadata is None or payload_bytes is None:
-                raise ValueError(f"[Worker {self.id}] Failed to serialize tensor data for key '{key}'. Either metadata or payload_bytes is None.")
-            metadata_list.append(metadata)
+            _, payload_bytes = mlt.serialize_gradient_to_custom_binary(self.tcp_sock, key, tensor)
+            if payload_bytes is None:
+                raise ValueError(f"[Worker {self.id}] Failed to serialize tensor data for key '{key}'.")
             payload_bytes_list.append(payload_bytes)
 
         # concatenate payload bytes into a single bytes object
         all_payload_bytes = b"".join(payload_bytes_list)
 
-        success = mlt.send_data_mlt(socks, addrs, metadata_list, all_payload_bytes, self.signal_counter)
+        success = mlt.send_data_mlt(socks, addrs, all_payload_bytes, self.signal_counter)
         if not success:
             raise ValueError(f"[Worker {self.id}] Failed to send tensor data using MLT protocol.")
 

--- a/extract_worker.py
+++ b/extract_worker.py
@@ -24,7 +24,13 @@ for worker_id in range(3):
 results = []
 for epoch, accuracies in worker_results.items():
     avg_accuracy = sum(accuracies) / len(accuracies)
-    results.append({"epoch": epoch, "avg_accuracy": round(avg_accuracy, 4), "worker_accuracies": [round(acc, 4) for acc in accuracies]})
+    results.append(
+        {
+            "epoch": epoch,
+            "avg_accuracy": round(avg_accuracy, 4),
+            "worker_accuracies": [round(acc, 4) for acc in accuracies],
+        }
+    )
 
 # Sort results by epoch number
 results.sort(key=lambda x: x["epoch"])

--- a/mininet/distributed_ml_topo.py
+++ b/mininet/distributed_ml_topo.py
@@ -117,7 +117,11 @@ def run_experiment():
     # Create log file for redirecting output
     os.makedirs(os.path.dirname(SERVER_LOG), exist_ok=True)
     # server_node.popen(server_cmd.split(), stdout=open(SERVER_LOG, "w"), stderr=open(SERVER_LOG, "a"))
-    server_proc = server_node.popen(server_cmd.split(), stdout=open(SERVER_LOG, "w"), stderr=open(SERVER_LOG, "a"))
+    server_proc = server_node.popen(
+        server_cmd.split(),
+        stdout=open(SERVER_LOG, "w"),
+        stderr=open(SERVER_LOG, "a"),
+    )
 
     # Give the server a moment to start up and bind to the port
     info("*** Waiting for server to initialize...\n")
@@ -134,17 +138,29 @@ def run_experiment():
     # Worker 0
     worker0_cmd = f"{PYTHON} -u {WORKER_SCRIPT} 0 {server_ip} {INITIAL_SERVER_PORT}"
     info(f"Executing on worker0: {worker0_cmd}\n")
-    worker0_proc = worker0_node.popen(worker0_cmd.split(), stdout=open(WORKER0_LOG, "w"), stderr=open(WORKER0_LOG, "a"))
+    worker0_proc = worker0_node.popen(
+        worker0_cmd.split(),
+        stdout=open(WORKER0_LOG, "w"),
+        stderr=open(WORKER0_LOG, "a"),
+    )
 
     # Worker 1
     worker1_cmd = f"{PYTHON} -u {WORKER_SCRIPT} 1 {server_ip} {INITIAL_SERVER_PORT}"
     info(f"Executing on worker1: {worker1_cmd}\n")
-    worker1_proc = worker1_node.popen(worker1_cmd.split(), stdout=open(WORKER1_LOG, "w"), stderr=open(WORKER1_LOG, "a"))
+    worker1_proc = worker1_node.popen(
+        worker1_cmd.split(),
+        stdout=open(WORKER1_LOG, "w"),
+        stderr=open(WORKER1_LOG, "a"),
+    )
 
     # Worker 2
     worker2_cmd = f"{PYTHON} -u {WORKER_SCRIPT} 2 {server_ip} {INITIAL_SERVER_PORT}"
     info(f"Executing on worker2: {worker2_cmd}\n")
-    worker2_proc = worker2_node.popen(worker2_cmd.split(), stdout=open(WORKER2_LOG, "w"), stderr=open(WORKER2_LOG, "a"))
+    worker2_proc = worker2_node.popen(
+        worker2_cmd.split(),
+        stdout=open(WORKER2_LOG, "w"),
+        stderr=open(WORKER2_LOG, "a"),
+    )
 
     # --- End Application Start ---
 

--- a/mlt-toy-example/worker.py
+++ b/mlt-toy-example/worker.py
@@ -21,7 +21,12 @@ def tensors_to_lists(tensor_dict: dict) -> dict:
     return {k: v.tolist() if isinstance(v, torch.Tensor) else v for k, v in tensor_dict.items()}
 
 
-def run_worker(server_ip: str, server_port: int, gradient_file: str, send_eval_data: bool = False):
+def run_worker(
+    server_ip: str,
+    server_port: int,
+    gradient_file: str,
+    send_eval_data: bool = False,
+):
     """
     Main function to run the worker/client logic.
     - Connects to the server.
@@ -75,7 +80,10 @@ def run_worker(server_ip: str, server_port: int, gradient_file: str, send_eval_d
         # 2.3 Send each gradient using the MLT protocol
         socks: dict[str, socket.socket] = {"tcp": tcp_sock, "udp": udp_sock}
         # server_addr_for_mlt = (server_ip, server_port)
-        addrs: dict[str, tuple] = {"tcp": (server_ip, server_port), "udp": (server_ip, server_port + 1)}
+        addrs: dict[str, tuple] = {
+            "tcp": (server_ip, server_port),
+            "udp": (server_ip, server_port + 1),
+        }
 
         for key, tensor in tensor_dict.items():
             print(f"\nWORKER: Processing '{key}' for sending...")

--- a/server_multithreading.py
+++ b/server_multithreading.py
@@ -130,6 +130,7 @@ class Server:
         dedicated_udp_sock = None
         have_received_metadata = False
         metadata_list = []
+        num_chunks = -666
 
         try:
             dedicated_udp_sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -149,13 +150,14 @@ class Server:
                 if not have_received_metadata:
                     print(f"[{tcp_addr}] Waiting to receive metadata from worker...")
                     metadata_list = utility.receive_data_tcp(client_tcp_sock)
+                    num_chunks = utility.receive_data_tcp(client_tcp_sock)
 
                     have_received_metadata = True
-                    print(f"[{tcp_addr}] Received metadata from worker.")
+                    print(f"[{tcp_addr}] Received metadata {len(metadata_list)} key-vals and {num_chunks} chunks from worker.")
 
                 # 1. Receive gradients from the worker
                 print(f"[{tcp_addr}] Waiting to receive gradients from worker...")
-                result = mlt.recv_data_mlt(socks, tcp_addr, signal_counter, metadata_list)
+                result = mlt.recv_data_mlt(socks, tcp_addr, signal_counter, metadata_list, num_chunks)
                 signal_counter += 1  # Increment signal counter after receiving
 
                 if result is None:


### PR DESCRIPTION
1. What's in the title is the biggest bug fix. Besides that:
2. Now all the metadata will one be sent once at the beginning of the training b/c the metadata (keys, shapes, tensor lengths, num_chunks) is the same across the whole training. So, in the middle of training, the only thing communicated with TCP is PROBE/BITMAP/STOP signals.

Bullet #1 decreased training time from 9 hours to 4 hours. Bullet #2, unexpected, increased training time from 4.5 hours to 5.5 hours. I absolutely admit that 2 improves our application run-time only slightly as the TCP overhead to transmit the metadata is small. However, there is absolutely no point transmitting redundant data over and over and by not doing that, the training time should absolutely not increase. 

For reviewers, changes are all in mlt.py, server_multithreading.py, distributed_trainer_multithreading.py. I added comments, zm on 8.8.2025 and zm on 8.9.2025 to help you locate the changes.

