### PR TITLE
Checksum; Reduce MLT Recv Complexity; Make debug message finer 

### DIFF
--- a/config.py
+++ b/config.py
@@ -77,3 +77,6 @@ TCP_MAX_RETRIES = 3  # Maximum number of retries for TCP connections
 
 # config 10: timeout
 probe_response_timeout = 0.001  # Timeout for probe responses in seconds
+
+# config 11: UDP send rate
+UDP_RATE = 100  # Mbps

--- a/mlt.py
+++ b/mlt.py
@@ -95,7 +95,7 @@ def _check_if_told_to_stop(
     return False, None  # No signal received, continue sending data
 
 
-def _count_bits(bitmap_data: bytearray):
+def count_bits(bitmap_data: bytearray):
     """
     Count the number of 0's and 1's in a bitmap (bytes object).
     Returns: (count_0, count_1)
@@ -115,7 +115,7 @@ def _count_bits(bitmap_data: bytearray):
     return count_0, count_1
 
 
-def _change_UDP_rate(update_rate: float):
+def change_UDP_rate(update_rate: float):
     """ 
     Update UDP rate to <update_rate>
     """
@@ -126,7 +126,7 @@ def _change_UDP_rate(update_rate: float):
 # Global tracking
 _BYTES_SENT_THIS_SECOND = 0
 _CURRENT_SECOND = int(time.time())
-def _UDP_send_rate_control(udp_sock: socket.socket, packet_to_send: bytearray, udp_host: str, udp_port: int):
+def UDP_send_rate_control(udp_sock: socket.socket, packet_to_send: bytearray, udp_host: str, udp_port: int):
     """
     A wrapper to UDP send function to add rate(flow) control
     """
@@ -255,7 +255,7 @@ def send_data_mlt(
                             #     (packet_to_send),
                             #     (udp_host, udp_port),
                             # )
-                            _UDP_send_rate_control(udp_sock, packet_to_send, udp_host, udp_port)
+                            UDP_send_rate_control(udp_sock, packet_to_send, udp_host, udp_port)
                             chunks_sent_this_round += 1
 
                         except Exception as e:
@@ -348,7 +348,7 @@ def send_data_mlt(
                 new_bitmap_data = utility.recv_all(tcp_sock, bitmap_len_to_recv)
 
                 if config.DEBUG: 
-                    zero_count, one_count = _count_bits(new_bitmap_data)
+                    zero_count, one_count = count_bits(new_bitmap_data)
                     print(f"SENDER MLT DEBUG: server request to resend {zero_count}/{zero_count + one_count} packets")
 
                 if not new_bitmap_data or len(new_bitmap_data) != bitmap_len_to_recv:

--- a/mlt.py
+++ b/mlt.py
@@ -459,7 +459,7 @@ def recv_data_mlt(socks: dict, tcp_addr: tuple, expected_counter: int, metadata_
                 time_with_ms = f"{now:%Y-%m-%d %H:%M:%S}.{now.microsecond // 1000:03d}"
                 if config.DEBUG:
                     print(
-                        f"[Worker {tcp_addr}] RECEIVER MLT(UDP): Received UDP packet of size {len(packet)} bytes ({udp_recv_counter}/{num_chunks}) at {time_with_ms}."
+                        f"[Worker {tcp_addr}] RECEIVER MLT(UDP): Received (pending check) UDP packet of size {len(packet)} bytes ({udp_recv_counter}/{num_chunks}) at {time_with_ms}."
                     )
                     # udp_recv_counter += 1
                 if len(packet) < 16:
@@ -481,7 +481,6 @@ def recv_data_mlt(socks: dict, tcp_addr: tuple, expected_counter: int, metadata_
                     continue
                 elif not seq < num_chunks:
                     if config.DEBUG: print(f"[Worker {tcp_addr}] RECEIVER MLT: Chunk Abandoned - 1: Chunk #{seq} should not be be bigger than num_chunk {num_chunks}")
-                
                 elif received_chunks[seq] is not None:
                     if config.DEBUG: print(f"[Worker {tcp_addr}] RECEIVER MLT: Chunk Abandoned - 2: Chunk #{seq} had been disposed already")
                 elif len(packet[16:]) != chunk_len_in_header:  
@@ -499,7 +498,7 @@ def recv_data_mlt(socks: dict, tcp_addr: tuple, expected_counter: int, metadata_
                     if config.DEBUG:
                         print(
                             f"[Worker {tcp_addr}] RECEIVER MLT(UDP): "
-                            f"Received chunk {seq}/{num_chunks} of size {len(packet[16:])} bytes at {time_with_ms}."
+                            f"Accepted chunk #{seq} of size {len(packet[16:])} bytes at {time_with_ms}."
                         )
                     udp_recv_counter += 1
                     


### PR DESCRIPTION
1. Checksum is embedded in chunk header, allowing data payload check at receiver, if accepted, close #22.
2. Chunk can be rejected for many reasons, and log will print the exact reason why the packet is not accepted. It will also print accepted seq number.
3. Add UDP_send_rate_control() function, to send UDP packet in a limited rate. The rate granularity is per second, if rate hit predefine limit, will wait for the rest of that second.